### PR TITLE
feat: Add hash options to FileSysCache constructor

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,7 @@ module.exports = {
   rules: {
     "@typescript-eslint/strict-boolean-expressions": "off",
     "no-useless-catch": "off",
-    "@typescript-eslint/prefer-nullish-coalescing": "off"
+    "@typescript-eslint/prefer-nullish-coalescing": "off",
+    "import/no-named-default": "warn"
   }
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ import { FileSysCache } from 'file-sys-cache'
 const cache = new FileSysCache({
     basePath: './.file-sys-cache', // Directory where cache will be stored
     defaultTTL: 60, // 60 seconds expiration time
+    hash: 'sha256', // Hashing alorithm
     debug: false, // Enabled debug mode
     autoInvalidate: false ,// Auto invalidate files from file-system and delete expired files automatically without need of triggering .invalidate()
     enableMonitoring: false // Enabled monitoring which exposes cache.monitoring.get(), cache.monitoring.reset()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-sys-cache",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A Node.js package providing efficient caching using the file system for storage.",
   "type": "module",
   "main": "./dist/file-sys-cache.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
-export { default as FileSysCache } from './lib/file-sys-cache.ts'
+// eslint-disable-next-line import/no-named-default
+import { default as FileSysCache } from './lib/file-sys-cache'
+import type { THashOptions } from './types/index.type'
+
+export { type THashOptions, FileSysCache }

--- a/src/lib/file-sys-cache.ts
+++ b/src/lib/file-sys-cache.ts
@@ -1,6 +1,12 @@
 import path from 'node:path'
 import { promises as fsPromises, readdirSync, rmSync, unlinkSync, statSync } from 'node:fs'
-import { type IArguments, type IGetArguments, type IOptions, type ISetArguments } from '../types/index.type.ts'
+import {
+  type IArguments,
+  type IGetArguments,
+  type IOptions,
+  type ISetArguments,
+  type THashOptions
+} from '../types/index.type.ts'
 import { formatFileName } from '../utils/format.util.ts'
 import FileSysCacheMonitoring, { monitoring } from './file-sys-cache-monitoring.ts'
 
@@ -17,14 +23,16 @@ const autoLog = {
 export default class FileSysCache {
   basePath: string
   defaultTTL: number
+  hash?: THashOptions
   debug: boolean
   autoInvalidate: boolean
   enableMonitoring: boolean
   monitoringInstance?: FileSysCacheMonitoring
 
-  constructor ({ basePath, defaultTTL, debug, autoInvalidate, enableMonitoring }: IOptions) {
+  constructor ({ basePath, defaultTTL, hash, debug, autoInvalidate, enableMonitoring }: IOptions) {
     this.basePath = basePath || './.file-sys-cache'
     this.defaultTTL = defaultTTL || 60 // 60 seconds
+    this.hash = hash || 'sha256'
     this.debug = debug || false
     this.autoInvalidate = autoInvalidate || false
     this.enableMonitoring = enableMonitoring || false
@@ -32,7 +40,7 @@ export default class FileSysCache {
 
   async set ({ fileName = '', key, payload, ttl = this.defaultTTL }: ISetArguments): Promise<string> {
     const FILE_TTL = ttl
-    const FILE_NAME = formatFileName({ fileName, key })
+    const FILE_NAME = formatFileName({ fileName, key, hash: this.hash })
     try {
       // Construct the cache folder path
       const cacheFolderPath = path.resolve(this.basePath)
@@ -83,7 +91,7 @@ export default class FileSysCache {
       }
     }
 
-    const FILE_NAME = formatFileName({ fileName, key })
+    const FILE_NAME = formatFileName({ fileName, key, hash: this.hash })
     try {
       // Construct the file path within the cache folder
       const filePath = path.resolve(this.basePath, `${FILE_NAME}`)

--- a/src/types/index.type.ts
+++ b/src/types/index.type.ts
@@ -1,6 +1,7 @@
 export interface IOptions {
   basePath?: string
   defaultTTL?: number
+  hash?: THashOptions
   debug?: boolean
   autoInvalidate?: boolean
   enableMonitoring?: boolean

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: {
-    'file-sys-cache': 'src/index.ts',
-    'file-sys-cache.types': 'src/types/index.type.ts'
+    'file-sys-cache': 'src/index.ts'
   },
   format: ['cjs', 'esm'], // Build for commonJS and ESmodules
   dts: true, // Generate declaration file (.d.ts)


### PR DESCRIPTION
This commit adds a `hash` property to the `IOptions` interface and `FileSysCache` constructor, allowing for hash customization in cache operations. It also updates the ESLint configuration to warn when named defaults are imported, and the documentation has been updated to reflect these changes. The module version in `package.json` has been bumped from 1.0.3 to 1.1.0.