### PR TITLE
feat: Add generateKey function and update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-sys-cache",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Node.js package providing efficient caching using the file system for storage.",
   "type": "module",
   "main": "./dist/file-sys-cache.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-named-default
 import { default as FileSysCache } from './lib/file-sys-cache'
+import { generateKey } from './utils/index.util.ts'
 import type { THashOptions } from './types/index.type'
 
-export { type THashOptions, FileSysCache }
+export { type THashOptions, FileSysCache, generateKey }

--- a/src/lib/file-sys-cache.ts
+++ b/src/lib/file-sys-cache.ts
@@ -159,6 +159,7 @@ export default class FileSysCache {
       }
       if (this.enableMonitoring) {
         monitoring.count.success.invalidate++
+        this.log()
       }
     } catch (_) {
       if (this.enableMonitoring) {

--- a/src/utils/index.util.ts
+++ b/src/utils/index.util.ts
@@ -1,0 +1,6 @@
+import { createHash } from 'node:crypto'
+import { type TBinaryToTextEncoding, type THashOptions } from '../types/index.type.ts'
+
+export const generateKey = (value: string, hash: THashOptions = 'sha256', encoding: TBinaryToTextEncoding = 'hex'): string => {
+  return createHash(hash).update(value).digest(encoding)
+}


### PR DESCRIPTION
A new utility function `generateKey` has been added which enables to generate keys based on the provided hash and encoding options. The `generateKey` function is also exported in the main index file. Additionally, a minor change has been made in the caching logic with an added log method and the package version has been revised to 1.1.1.