### PR TITLE
chore: Update generateKey function to accept objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-sys-cache",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A Node.js package providing efficient caching using the file system for storage.",
   "type": "module",
   "main": "./dist/file-sys-cache.cjs",

--- a/src/utils/index.util.ts
+++ b/src/utils/index.util.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import { type TBinaryToTextEncoding, type THashOptions } from '../types/index.type.ts'
 
-export const generateKey = (value: string, hash: THashOptions = 'sha256', encoding: TBinaryToTextEncoding = 'hex'): string => {
-  return createHash(hash).update(value).digest(encoding)
+export const generateKey = (payload: object, hash: THashOptions = 'sha256', encoding: TBinaryToTextEncoding = 'hex'): string => {
+  const data = JSON.stringify(payload)
+  return createHash(hash).update(data).digest(encoding)
 }


### PR DESCRIPTION
The generateKey function has been updated to accept an object as a parameter rather than a string. This change also comes with an update to our version number in package.json, now 1.1.2. This improvement in the utility enhances our caching capabilities.