### PR TITLE
fix(deps): Update dependencies in package-lock.json and add 'pinceau' to package.json

### DIFF
--- a/_docs/package-lock.json
+++ b/_docs/package-lock.json
@@ -13,7 +13,8 @@
         "@nuxt/eslint-config": "^0.2.0",
         "@types/node": "^20.11.24",
         "eslint": "^8.57.0",
-        "nuxt": "^3.10.3"
+        "nuxt": "^3.10.3",
+        "pinceau": "0.15.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1908,6 +1909,43 @@
         "pinceau": "^0.18.8"
       }
     },
+    "node_modules/@nuxt-themes/tokens/node_modules/@unocss/reset": {
+      "version": "0.50.8",
+      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-0.50.8.tgz",
+      "integrity": "sha512-2WoM6O9VyuHDPAnvCXr7LBJQ8ZRHDnuQAFsL1dWXp561Iq2l9whdNtPuMcozLGJGUUrFfVBXIrHY4sfxxScgWg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nuxt-themes/tokens/node_modules/pinceau": {
+      "version": "0.18.9",
+      "resolved": "https://registry.npmjs.org/pinceau/-/pinceau-0.18.9.tgz",
+      "integrity": "sha512-GJ+l8a5Y+7PP/diwuajJhd2QONTIFkk2YXjrVTh7QKC3sMQEphpLH6ZJfXSeeSonQ0/BnhrrMi9a5e14mmqXug==",
+      "dev": true,
+      "dependencies": {
+        "@unocss/reset": "^0.50.3",
+        "@volar/vue-language-core": "^1.2.0",
+        "acorn": "^8.8.2",
+        "chroma-js": "^2.4.2",
+        "consola": "^3.0.1",
+        "csstype": "^3.1.1",
+        "defu": "^6.1.2",
+        "magic-string": "^0.30.0",
+        "nanoid": "^4.0.1",
+        "ohash": "^1.0.0",
+        "paneer": "^0.1.0",
+        "pathe": "^1.1.0",
+        "postcss-custom-properties": "13.1.4",
+        "postcss-dark-theme-class": "0.7.3",
+        "postcss-nested": "^6.0.1",
+        "recast": "^0.22.0",
+        "scule": "^1.0.0",
+        "style-dictionary-esm": "^1.3.7",
+        "unbuild": "^1.1.2",
+        "unplugin": "^1.1.0"
+      }
+    },
     "node_modules/@nuxt-themes/typography": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@nuxt-themes/typography/-/typography-0.11.0.tgz",
@@ -1919,6 +1957,43 @@
         "nuxt-icon": "^0.3.3",
         "pinceau": "^0.18.8",
         "ufo": "^1.1.1"
+      }
+    },
+    "node_modules/@nuxt-themes/typography/node_modules/@unocss/reset": {
+      "version": "0.50.8",
+      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-0.50.8.tgz",
+      "integrity": "sha512-2WoM6O9VyuHDPAnvCXr7LBJQ8ZRHDnuQAFsL1dWXp561Iq2l9whdNtPuMcozLGJGUUrFfVBXIrHY4sfxxScgWg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nuxt-themes/typography/node_modules/pinceau": {
+      "version": "0.18.9",
+      "resolved": "https://registry.npmjs.org/pinceau/-/pinceau-0.18.9.tgz",
+      "integrity": "sha512-GJ+l8a5Y+7PP/diwuajJhd2QONTIFkk2YXjrVTh7QKC3sMQEphpLH6ZJfXSeeSonQ0/BnhrrMi9a5e14mmqXug==",
+      "dev": true,
+      "dependencies": {
+        "@unocss/reset": "^0.50.3",
+        "@volar/vue-language-core": "^1.2.0",
+        "acorn": "^8.8.2",
+        "chroma-js": "^2.4.2",
+        "consola": "^3.0.1",
+        "csstype": "^3.1.1",
+        "defu": "^6.1.2",
+        "magic-string": "^0.30.0",
+        "nanoid": "^4.0.1",
+        "ohash": "^1.0.0",
+        "paneer": "^0.1.0",
+        "pathe": "^1.1.0",
+        "postcss-custom-properties": "13.1.4",
+        "postcss-dark-theme-class": "0.7.3",
+        "postcss-nested": "^6.0.1",
+        "recast": "^0.22.0",
+        "scule": "^1.0.0",
+        "style-dictionary-esm": "^1.3.7",
+        "unbuild": "^1.1.2",
+        "unplugin": "^1.1.0"
       }
     },
     "node_modules/@nuxt/content": {
@@ -3575,9 +3650,9 @@
       }
     },
     "node_modules/@unocss/reset": {
-      "version": "0.50.8",
-      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-0.50.8.tgz",
-      "integrity": "sha512-2WoM6O9VyuHDPAnvCXr7LBJQ8ZRHDnuQAFsL1dWXp561Iq2l9whdNtPuMcozLGJGUUrFfVBXIrHY4sfxxScgWg==",
+      "version": "0.49.8",
+      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-0.49.8.tgz",
+      "integrity": "sha512-QIEhXCDyYZvqfyzg/3UiiWw2B0rdJpvswDEWudnYLm0Z73NsOjgx6TQpOsfDRKqRnDF+N9Kbs7gs60O/WAwR8g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -5437,12 +5512,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true,
       "engines": {
-        "node": ">=16"
+        "node": ">= 12"
       }
     },
     "node_modules/commondir": {
@@ -11518,31 +11593,71 @@
       }
     },
     "node_modules/pinceau": {
-      "version": "0.18.9",
-      "resolved": "https://registry.npmjs.org/pinceau/-/pinceau-0.18.9.tgz",
-      "integrity": "sha512-GJ+l8a5Y+7PP/diwuajJhd2QONTIFkk2YXjrVTh7QKC3sMQEphpLH6ZJfXSeeSonQ0/BnhrrMi9a5e14mmqXug==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/pinceau/-/pinceau-0.15.4.tgz",
+      "integrity": "sha512-QQwmaR7NdMBl0k8ok+Vw2kKl32Gv9nO6JindHQAWsSz/1U68o1L1iriH7u4GXE9GLm0DB8DT6Mn83G2LPd1Pbg==",
       "dev": true,
       "dependencies": {
-        "@unocss/reset": "^0.50.3",
-        "@volar/vue-language-core": "^1.2.0",
+        "@unocss/reset": "^0.49.4",
+        "@volar/vue-language-core": "^1.0.24",
         "acorn": "^8.8.2",
         "chroma-js": "^2.4.2",
-        "consola": "^3.0.1",
+        "consola": "^2.15.3",
         "csstype": "^3.1.1",
         "defu": "^6.1.2",
-        "magic-string": "^0.30.0",
+        "magic-string": "^0.29.0",
         "nanoid": "^4.0.1",
         "ohash": "^1.0.0",
         "paneer": "^0.1.0",
         "pathe": "^1.1.0",
-        "postcss-custom-properties": "13.1.4",
+        "postcss-custom-properties": "13.1.3",
         "postcss-dark-theme-class": "0.7.3",
-        "postcss-nested": "^6.0.1",
+        "postcss-nested": "^6.0.0",
         "recast": "^0.22.0",
         "scule": "^1.0.0",
-        "style-dictionary-esm": "^1.3.7",
-        "unbuild": "^1.1.2",
-        "unplugin": "^1.1.0"
+        "style-dictionary-esm": "^1.2.0",
+        "unbuild": "^1.1.1",
+        "unplugin": "^1.0.1"
+      }
+    },
+    "node_modules/pinceau/node_modules/consola": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
+      "dev": true
+    },
+    "node_modules/pinceau/node_modules/magic-string": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+      "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/pinceau/node_modules/postcss-custom-properties": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-13.1.3.tgz",
+      "integrity": "sha512-15equAsfqtnr7jyzes6vyaGdAiNmKd+50FZ35/E/huBNBt7PgGMSNL/4o765nnNoP2dmaMJklb3FwJf3fdRcpA==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/cascade-layer-name-parser": "^1.0.0",
+        "@csstools/css-parser-algorithms": "^2.0.0",
+        "@csstools/css-tokenizer": "^2.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/pkg-types": {
@@ -13500,6 +13615,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/style-dictionary-esm/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/style-dictionary-esm/node_modules/glob": {
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
@@ -15192,15 +15316,6 @@
         "vue-tsc": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-checker/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/vite-plugin-checker/node_modules/npm-run-path": {

--- a/_docs/package.json
+++ b/_docs/package.json
@@ -16,6 +16,7 @@
     "@nuxt/eslint-config": "^0.2.0",
     "@types/node": "^20.11.24",
     "eslint": "^8.57.0",
-    "nuxt": "^3.10.3"
+    "nuxt": "^3.10.3",
+    "pinceau": "0.15.4"
   }
 }


### PR DESCRIPTION
This commit updates multiple dependencies within the package-lock.json file, including adding and modifying various dependencies related to the 'pinceau' and '@unocss/reset' packages. Moreover, it incorporates 'pinceau' version 0.15.4 into the package.json file.