### PR TITLE
feat: Add 'files' method to FileSysCache class

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ await cache.set({ fileName: 'myFileName', key: 'myUniqueKey', payload: myPayload
 // Retrieve cached data by file name prefix and file name
 const data = await cache.get({ fileName: 'myFileName', key: 'myUniqueKey' });
 
+// Retrieve current list of files inside cache
+const data = await cache.files();
+
 // Flush cache by passing regex
 await cache.flushByRegex('myString', 'myString2'); // Flush cache by regex match (single or multiple same matches)
 

--- a/_docs/content/2.api/1.functions.md
+++ b/_docs/content/2.api/1.functions.md
@@ -20,6 +20,44 @@ const data = await cache.get({ fileName: 'myFileName', key: 'myUniqueKey' });
 ```
 ---
 
+###  Get Files
+
+::code-group
+
+```ts [Code]
+const files = cache.files()
+```
+
+
+```json [Response]
+[
+  { 
+    "name": "myFileNameFirst hash_132d085c88b595f1ef63d51afcc700028145f194732ae460aaec04f574c5c5de",
+    "size": { 
+      "bytes": 75,
+      "megabytes": 0.00007152557373046875
+    },
+    "ttl": 60,
+    "expiration": 1710405034332,
+    "expires_in": 59.997
+  },
+  { 
+    "name": "myFileNameSecond hash_132d085c88b595f1ef63d51afcc700028145f194732ae460aaec04f574c5c5de",
+    "size": {
+      "bytes": 75,
+      "megabytes": 0.00007152557373046875
+    },
+    "ttl": 60,
+    "expiration": 1710405034334,
+    "expires_in": 59.998
+  }
+]
+```
+
+::
+
+---
+
 ###  Flush all
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-sys-cache",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A Node.js package providing efficient caching using the file system for storage.",
   "type": "module",
   "main": "./dist/file-sys-cache.cjs",

--- a/src/lib/file-sys-cache.spec.ts
+++ b/src/lib/file-sys-cache.spec.ts
@@ -145,6 +145,35 @@ describe('FileSysCache', () => {
     })
   })
 
+  describe('files', () => {
+    const basePath = './.unit-file-sys-cache--files'
+    afterEach(() => {
+      // Delete cache folder after each test
+      rmSync(basePath, { recursive: true, force: true })
+    })
+    it('should return files', async () => {
+      const cache = new FileSysCache({ basePath })
+
+      await cache.set({ fileName: '1', key, payload })
+      await cache.set({ fileName: '2', key, payload })
+      const result = await cache.files()
+      const entry = result[0]
+      expect(Array.isArray(result)).toBeTruthy()
+      expect(entry.name).toBeDefined()
+      expect(entry.name).toContain('1 hash_')
+      expect(typeof entry.size).toBe('object')
+      expect(entry.size).toBeDefined()
+      expect(entry.size.bytes).toBeDefined()
+      expect(entry.size.bytes).toBe(75)
+      expect(entry.size.megabytes).toBeDefined()
+      expect(entry.size.megabytes).toBe(0.00007152557373046875)
+
+      expect(entry.ttl).toBe(60)
+      expect(entry.expiration).toBeDefined()
+      expect(entry.expires_in).toBeDefined()
+    })
+  })
+
   describe('invalidate', () => {
     const basePath = './.unit-file-sys-cache--invalidate'
     afterAll(() => {


### PR DESCRIPTION
This update introduces a new 'files' method in the FileSysCache class. The 'files' method returns a list of files in the cache including their attributes such as name, size, ttl, expiration, and 'expires_in'. Unit tests and documentation for this new feature have been also added. The package version has been bumped from 2.0.1 to 2.1.0 to reflect this addition.